### PR TITLE
support other compilers, avoid warnings

### DIFF
--- a/res/cmdtab.rc
+++ b/res/cmdtab.rc
@@ -13,24 +13,20 @@
 	{
 		BLOCK "VarFileInfo"
 		{
-			VALUE "Translation", 0x409, 1200
+			VALUE "Translation", 0x409, 1252
 		}
 		BLOCK "StringFileInfo"
 		{
-			BLOCK "040904B0"
+			BLOCK "040904E4"
 			{
-				VALUE "Comments",		"N/A"
-				VALUE "CompanyName",		"Stian Gudmundsen HÃ¸iland"
+				VALUE "CompanyName",		"Stian Gudmundsen Høiland"
 				VALUE "FileDescription",	"macOS-style Alt-Tab window switcher alternative"
 				VALUE "FileVersion",		"1.5.1"
 				VALUE "InternalName",		"cmdtab"
-				VALUE "LegalCopyright",		"Copyright (C) 2023 Stian Gudmundsen HÃ¸iland"
-				VALUE "LegalTrademarks",	"N/A"
+				VALUE "LegalCopyright",		"Copyright (C) 2023 Stian Gudmundsen Høiland"
 				VALUE "OriginalFilename",	"cmdtab.exe"
-				VALUE "PrivateBuild";		"N/A"
 				VALUE "ProductName",		"cmdtab"
 				VALUE "ProductVersion",		"1.5.1"
-				VALUE "SpecialBuild",		"N/A"
 			}
 		}
 	}


### PR DESCRIPTION
I love this beautiful, lightweight app! Unfortunately, the code only compiles with the Microsoft compiler, which may discourage some potential contributors from working on fixes and new features.  
  
Sorry for the huge diff 😰 No hard feelings if you reject the PR. The updates are trivial and don't change the program logic, though.  
Consider it as a bunch of proposals to make it compile using other compilers like MinGW/gcc or clang. It also addresses a couple of compiler warnings that don't prevent from compiling. However, it was an overwhelming list when I first tried to compile the code. Besides of that, some personal preferences are included. I tried to explain my intention; however you still may not love them.  
So, whatever works for you is also fine with me. Feel free to merge, tell me what changes you want me to do, or just reject and independently take over certain updates that you like 😊  
  
## Source:  
- Specify a minimum version for _WIN32_WINNT to unhide certain definitions in the WinAPI headers (e.g. EVENT_OBJECT_UNCLOAKED).  
- Include `initguid.h` before any of the COM-related headers.  
- Don't mess with `bool`. It became a built-in type in modern C, hence any re-definition will not even compile. Instead use the C `bool` type whenever you want to deal with Boolean values (this is an indicator for the compiler to make the processor use flags rather than values if beneficial), and use `BOOL` where the platform API wants to see a 32-bit value.  
- Don't mess with `int` and `long`. They are distinct types in C, so compilers may throw warnings.  
- Don't use fixed-size integers in place of native-size types. Native-size types prepare the code to work perfectly fine if you compile it as a 32-bit app.  
- Don't make every handle your own `void*` type. Not only that the WinAPI definitions are descriptive enough to know at first glance what kind of handle they denote, using them also avoids type casts of values and function pointers that may hide serious issues.
- Callback functions may need the the right calling convention. Macros like `CALLBACK` or `WINAPI` insert a `__stdcall` if required for the target platform (32-bit).  
- I'm only mildly concerned about the `null` type. However, because you asked, C dudes are used to seeing `NULL` and they know exactly what it means. When I've seen `null` in the code, my first consideration was something like "OK, that can't be the same as NULL, otherwise NULL would've been used here. Lemme just look for the definition to understand what this is about ...". So, IMO, all you gain is confusion 😅  
- I'm also mildly concerned about `u16` as this name just indicates the wrong semantics. Your intention is using it as a character type. So, if you're really worried about the different size of `wchar_t` on Windows (although the code wouldn't even compile for any other OS), better use `WCHAR` or define something like `char16`.  
- `stdint.h` defines types with names that describe what they are. Make use of them as long as they don't clash. IMO, no need to reinvent the wheel.  
- Last not least, don't return a value from a void function.  
  
## Resource:  
- The resource compiler destroyed your name. You saved the file UTF-8 encoded but specified the translation being UTF-16. However, some resource compilers still don't support UTF-16 encoded files. My way to work around this issue is to save the file in the ancient Windows-1252 ANSI encoding. All resource compilers that I'm aware of support it, it is preinstalled on every Windows machine all over the world, and it supports the ø in your name. Of course the instructions of how to translate the text needs to be updated accordingly (1252 and hex 04E4, respectively).  
- You can just leave out string values that you don't use. Clang's resource compiler rejected the semicolon after the "PrivateBuild" key anyway. (Took me ages to spot it 🤣)  
  