### PR TITLE
use monitor where the mouse pointer is at

### DIFF
--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -936,14 +936,20 @@ static void SelectNextWindow(bool applevel, bool reverse, bool wrap)
 
 static void ResizeSwitcher(void)
 {
+	// Use the monitor where the mouse pointer is currently placed (#5)
+	POINT mousePos = { 0 };
+	GetCursorPos(&mousePos);
+	MONITORINFO mi = { .cbSize = sizeof(MONITORINFO) };
+	GetMonitorInfoW(MonitorFromPoint(mousePos, MONITOR_DEFAULTTONEAREST), &mi);
+
 	u32   iconsWidth = AppsCount * Config.iconWidth;
 	u32 paddingWidth = AppsCount * Config.iconHorzPadding * 2;
 	u32  marginWidth =         2 * Config.switcherHorzMargin;
 
 	u32 w = iconsWidth + paddingWidth + marginWidth;
 	u32 h = Config.switcherHeight;
-	u32 x = GetSystemMetrics(SM_CXSCREEN) / 2 - (w / 2);
-	u32 y = GetSystemMetrics(SM_CYSCREEN) / 2 - (h / 2);
+	u32 x = (mi.rcMonitor.right - mi.rcMonitor.left) / 2 - (w / 2);
+	u32 y = (mi.rcMonitor.bottom - mi.rcMonitor.top) / 2 - (h / 2);
 
 	MoveWindow(Switcher, x, y, w, h, false); // Yes, "MoveWindow" means "ResizeWindow"
 


### PR DESCRIPTION
Make the switcher pop up at the monitor where the mouse cursor is currently at.  
  
closes #5 