### PR TITLE
Fix centering per monitor

### DIFF
--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -948,8 +948,8 @@ static void ResizeSwitcher(void)
 
 	u32 w = iconsWidth + paddingWidth + marginWidth;
 	u32 h = Config.switcherHeight;
-	u32 x = (mi.rcMonitor.right - mi.rcMonitor.left) / 2 - (w / 2);
-	u32 y = (mi.rcMonitor.bottom - mi.rcMonitor.top) / 2 - (h / 2);
+	u32 x = mi.rcMonitor.left + (mi.rcMonitor.right - mi.rcMonitor.left - w) / 2;
+	u32 y = mi.rcMonitor.top + (mi.rcMonitor.bottom - mi.rcMonitor.top - h) / 2;
 
 	MoveWindow(Switcher, x, y, w, h, false); // Yes, "MoveWindow" means "ResizeWindow"
 

--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -948,8 +948,8 @@ static void ResizeSwitcher(void)
 
 	u32 w = iconsWidth + paddingWidth + marginWidth;
 	u32 h = Config.switcherHeight;
-	u32 x = mi.rcMonitor.left + (mi.rcMonitor.right - mi.rcMonitor.left - w) / 2;
-	u32 y = mi.rcMonitor.top + (mi.rcMonitor.bottom - mi.rcMonitor.top - h) / 2;
+	i32 x = mi.rcMonitor.left + (mi.rcMonitor.right - mi.rcMonitor.left - w) / 2;
+	i32 y = mi.rcMonitor.top + (mi.rcMonitor.bottom - mi.rcMonitor.top - h) / 2;
 
 	MoveWindow(Switcher, x, y, w, h, false); // Yes, "MoveWindow" means "ResizeWindow"
 


### PR DESCRIPTION
The calculation in #14 didn't take the origin of the monitor into account. Coordinates {0, 0} were assumed, while they are actually {left, top} on the virtual screen.  

For reference and for evidence:  
https://learn.microsoft.com/en-us/windows/win32/gdi/positioning-objects-on-a-multiple-display-setup  
  
For context:  
https://learn.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen  
