### PR TITLE
Make dark/light work, fix race conditions

### DIFF
--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -1436,12 +1436,6 @@ static LRESULT CALLBACK KeyboardHookProcedure(int code, WPARAM wparam, LPARAM lp
 		return 1;
 }
 
-static void OnWindowCreate(void)
-{
-	// Make the codepath hot to prevent kbd hook from timing out on first use
-	UpdateApps();
-}
-
 static void OnWindowPaint(void)
 {
 	// Double buffered drawing:
@@ -1523,9 +1517,6 @@ static void OnShellWindowActivated(handle hwnd)
 static i64 WindowProcedure(handle hwnd, u32 message, u64 wparam, i64 lparam)
 {
 	switch (message) {
-		case WM_CREATE:
-			OnWindowCreate();
-			break;
 		case WM_PAINT:
 			OnWindowPaint();
 			break;
@@ -1627,7 +1618,7 @@ static int RunCmdTab(handle instance, u16 *args)
 	// Rounded window corners
 	DWM_WINDOW_CORNER_PREFERENCE corners = DWMWCP_ROUND;
 	DwmSetWindowAttribute(Switcher, DWMWA_WINDOW_CORNER_PREFERENCE, &corners, sizeof corners);
-
+	// Make the codepath hot to prevent kbd hook from timing out on first use
 	// Ensure the drawing is initialized, it might be instantly used in OnWindowPaint()
 	UpdateApps();
 	ResizeSwitcher(); // NOTE Must call ResizeSwitcher after UpdateApps, before RedrawSwitcher & before ShowSwitcher

--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -1032,7 +1032,7 @@ static void RedrawSwitcher(void)
 
 		if (app != SelectedApp) {
 			// Draw only icon, with window background
-			DrawIconEx(DrawingContext, left, top, app->icon, width, height, 0, windowBackground, DI_NORMAL);
+			DrawIconEx(DrawingContext, left, top, app->icon, width, height, 0, NULL, DI_NORMAL);
 		} else {
 			// Draw selection rectangle and icon, with selection background
 			RoundRect(DrawingContext, left - SEL_VERT_OFF, top - SEL_HORZ_OFF, right + SEL_VERT_OFF, bottom + SEL_HORZ_OFF, SEL_RADIUS, SEL_RADIUS);


### PR DESCRIPTION
We only used the dark theme while the code already contained some preparation to respect the user settings of whether apps should appear dark or light.  

While working on that, I realized that window messages and hooked events are processed asynchronously which results in quite some race conditions making the app unstable.  

Besides of that I also tried to get the GDI drawing a little less brittle. Not sure if I understood the manpages correctly though.  
