### PR TITLE
Fix out-of-bounds access in SetKey for vkCodes >= 128

### DIFF
--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -65,6 +65,7 @@
 #define true 1
 #define null NULL // WHY IS EVERYONE SCREAMING
 
+typedef unsigned char        u8;
 typedef wchar_t             u16; // "Microsoft implements wchar_t as a two-byte unsigned value."
 typedef unsigned int        u32;
 typedef unsigned long long  u64;
@@ -638,7 +639,7 @@ static handle      HistoryHooks[2]; // Hook handles for WinEvent window activati
 static handle      History[128];    // Window handles from window activation events (MRU). Deduplicated, so prior activations are moved to the front
 static iz          HistoryCount;    // Number of elements in 'History' array
 static handle      KeyboardHook;    // Handle for low-level keyboard hook
-static u16         Keyboard[16];    // 256 bits to track key repeat for low-level keyboard hook
+static u8          Keyboard[32];    // 256 bits to track key repeat for low-level keyboard hook
 static struct app  Apps[128];       // Apps to be displayed in switcher
 static iz          AppsCount;       // Number of elements in 'Apps' array
 static struct app *SelectedApp;     // Pointer to one of the elements in 'Apps' array. The app for the 'SelectedWindow'


### PR DESCRIPTION
Keyboard was declared as u16[16] (256 bits total) but indexed in byte granularity: Keyboard[key/CHAR_BIT] produces element indices 0-31, past the end of a 16-element array. Any vkCode >= 128 read and wrote single bits into adjacent static data — including VK_LSHIFT/VK_RSHIFT (0xA0/0xA1) and VK_OEM_3 (0xC0), the default window-cycle hotkey.

The bit math was also only using bits 0-7 of each u16, halving the intended capacity.

Add a u8 typedef and declare Keyboard as u8[32] so the existing key/CHAR_BIT and key%CHAR_BIT indexing is correct by construction: indices 0-31, bits 0-7, one bit per vkCode 0-255.

Fixes #33