### PR TITLE
Update Log() to run if _DEBUG is defined instead of not defined

### DIFF
--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -151,7 +151,7 @@ static void Print(u16 *fmt, ...)
 
 static void Log(u16 *fmt, ...)
 {
-	#ifndef _DEBUG
+	#ifdef _DEBUG
 	u16 buffer[2048];
 	va_list args;
 	va_start(args, fmt);


### PR DESCRIPTION
Updating Log() to run if _DEBUG is defined instead of when it is not defined which matches testing and debugging intent

fixes #34