### PR TITLE
Use PROCESS_QUERY_LIMITED_INFORMATION in GetExePath

### DIFF
--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -260,7 +260,7 @@ static string GetExePath(handle hwnd)
 	string path = {0};
 	ULONG pid;
 	GetWindowThreadProcessId(hwnd, &pid);
-	handle process = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
+	handle process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
 	if (!process || process == INVALID_HANDLE_VALUE) {
 		Log(L"WARNING couldn't open process with pid: %u\n", pid);
 		return path;


### PR DESCRIPTION
QueryFullProcessImageNameW only requires `QUERY_LIMITED_INFORMATION`. The previous `QUERY_INFORMATION | VM_READ` was broader than needed and throws findings on antivirus software (Currently at least Microsoft Defender). Nothing in `GetExePath` reads target process memory.

`LIMITED` is also granted for many elevated/protected processes where the wider rights are denied, so this reduces "couldn't open process" failures and lets more windows be listed without running as admin.