### PR TITLE
Guard debug breakpoints and fix IImageList leak on icon failure

### DIFF
--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -420,7 +420,10 @@ static handle GetAppIcon(string *filepath)
 	SHFILEINFOW info = {0};
 	if (!SHGetFileInfoW(filepath->text, 0, &info, sizeof info, SHGFI_SYSICONINDEX)) { // 2nd arg: -1, 0 or FILE_ATTRIBUTE_NORMAL
 		Print(L"suspicious SHGetFileInfoW return"); // SHGetFileInfoW has special return with SHGFI_SYSICONINDEX flag, which I think should never fail (docs unclear?)
+		#ifdef _DEBUG
 		__debugbreak();
+		#endif
+		IImageList_Release(list);
 		return null;
 	}
 	HICON icon = {0};
@@ -1716,7 +1719,7 @@ static LRESULT CALLBACK KeyboardHookProcedure(int code, WPARAM wparam, LPARAM lp
 			// ========================================
 			// Debug
 			// ========================================
-
+            #ifdef _DEBUG
 			bool keyF11Down = keyCode == VK_F11 && keyDown && !keyRepeat;
 			bool keyF12Down = keyCode == VK_F12 && keyDown && !keyRepeat;
 
@@ -1727,6 +1730,7 @@ static LRESULT CALLBACK KeyboardHookProcedure(int code, WPARAM wparam, LPARAM lp
 			if (keyF11Down) {
 				PrintApps();
 			}
+			#endif
 
 			// ========================================
 			// Hook management

--- a/src/cmdtab.c
+++ b/src/cmdtab.c
@@ -260,7 +260,7 @@ static string GetExePath(handle hwnd)
 	string path = {0};
 	ULONG pid;
 	GetWindowThreadProcessId(hwnd, &pid);
-	handle process = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
+	handle process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
 	if (!process || process == INVALID_HANDLE_VALUE) {
 		Log(L"WARNING couldn't open process with pid: %u\n", pid);
 		return path;


### PR DESCRIPTION
`__debugbreak()` with no debugger attached raises an unhandled breakpoint exception and terminates the process. Two paths hit it in release builds:
- F12 while the switcher is open (the debug hotkey block in `KeyboardHookProcedure`, reachable by any user since the hook is
  global while the switcher is active)
- `SHGetFileInfoW` returning 0 in `GetAppIcon`

Wrap the F11/F12 debug hotkey block and the GetAppIcon breakpoint in `#ifdef _DEBUG`. In release, `F11`/`F12` now fall through to the input sink like other keys, and the `GetAppIcon` failure path returns `null` as it already did.

Also fix a leak on that same failure path: the `IImageList` acquired via `SHGetImageList` was only released on success, so the early return null leaked the reference. Release it before returning.

Fixes #35 