### PR TITLE
Disable linker manifest embedding under MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ set(BUILD_TYPE "MinSizeRel")
 
 add_executable(cmdtab WIN32 "src/cmdtab.c" "res/cmdtab.rc")
 
+# cmdtab.rc already embeds res/cmdtab.manifest (resource type 24, id 1);
+# keep the linker from embedding a second, conflicting default manifest
+if(MSVC)
+	target_link_options(cmdtab PRIVATE /MANIFEST:NO)
+endif()
+
 #set_property(TARGET ${PROJECT_NAME} PROPERTY
     #LINK_FLAGS /MANIFESTUAC:"level='highestAvailable' uiAccess='true'"
 #)


### PR DESCRIPTION
`res/cmdtab.rc` already embeds `cmdtab.manifest` as `RT_MANIFEST id 1`. The CMake Visual Studio generator additionally embeds a linker-generated default manifest, which fails the link with CVT1100 (duplicate resource) on current MSVC toolchains:
```
  CVTRES : fatal error CVT1100: duplicate resource.  type:MANIFEST, name:1
  LINK : fatal error LNK1123: failure during conversion to COFF
```
Pass `/MANIFEST:NO` so the .rc-embedded manifest, which the `mingw` build also uses, is the only one.